### PR TITLE
Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 
-sudo:false
+sudo: false
 
 node_js:
   - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: node_js
 
+sudo:false
+
 node_js:
   - "0.10"
+  - "0.12"
+
+after_success:
+ - env
+ - npm run coverage

--- a/package.json
+++ b/package.json
@@ -17,12 +17,15 @@
     "benchmark": "1.0.x",
     "dox": "^0.7.0",
     "doxme": "^1.8.2",
+    "istanbul": "~0.3.17",
+    "coveralls": "~2.11.2",
     "tape": "2.13.x"
   },
   "main": "./index.js",
   "scripts": {
     "test": "node test/test.js",
-    "doc": "dox -r < index.js | doxme --readme > README.md"
+    "doc": "dox -r < index.js | doxme --readme > README.md",
+    "coverage": "istanbul cover tape test/*test.js && coveralls < ./coverage/lcov.info"
   },
   "bin": {
     "tiletype": "bin/tiletype.js"

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 # tiletype
 
 [![build status](https://secure.travis-ci.org/mapbox/tiletype.png)](http://travis-ci.org/mapbox/tiletype)
+[![Coverage Status](https://coveralls.io/repos/mapbox/tiletype/badge.svg?branch=coverage&service=github)](https://coveralls.io/github/mapbox/tiletype?branch=coverage)
 
 detect common map tile formats from a buffer
 


### PR DESCRIPTION
 - adds coverage reporting + posts to coveralls.io
 - starts testing on node v0.12.x