### PR TITLE
Add typescript definition to tiletype

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,11 @@
 /// <reference types="node" />
 
-interface Header {
+export interface Header {
   'Content-Type'?: string
   'Content-Encoding'?: string
 }
+
+export type extensions = 'png' | 'pbf' | 'jpg' | 'webp'
 
 /**
  * Given a buffer of unknown data, return either a format as an extension
@@ -19,7 +21,7 @@ interface Header {
  * @param {Buffer} buffer input
  * @returns {String|boolean} identifier
  */
-export function type(buffer: Buffer): string | boolean
+export function type(buffer: Buffer): extensions | boolean
 
 /**
  * Return headers - Content-Type and Content-Encoding -
@@ -37,4 +39,4 @@ export function headers(buffer: Buffer): Header
  * @param {Buffer} buffer input
  * @returns {Array<number>|boolean} dimensions
  */
-export function dimensions(buffer: Buffer): Array<number> | boolean
+export function dimensions(buffer: Buffer): [number, number] | boolean

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,40 @@
+/// <reference types="node" />
+
+interface Header {
+  'Content-Type'?: string
+  'Content-Encoding'?: string
+}
+
+/**
+ * Given a buffer of unknown data, return either a format as an extension
+ * string or false if the type cannot be determined.
+ *
+ * Potential options are:
+ *
+ * * png
+ * * pbf
+ * * jpg
+ * * webp
+ *
+ * @param {Buffer} buffer input
+ * @returns {String|boolean} identifier
+ */
+export function type(buffer: Buffer): string | boolean
+
+/**
+ * Return headers - Content-Type and Content-Encoding -
+ * for a response containing this kind of image.
+ *
+ * @param {Buffer} buffer input
+ * @returns {Object} headers
+ */
+export function headers(buffer: Buffer): Header
+
+/**
+ * Determine the width and height of an image contained in a buffer,
+ * returned as a [x, y] array.
+ *
+ * @param {Buffer} buffer input
+ * @returns {Array<number>|boolean} dimensions
+ */
+export function dimensions(buffer: Buffer): Array<number> | boolean

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function headers(buffer) {
  * returned as a [x, y] array.
  *
  * @param {Buffer} buffer input
- * @param {Array|boolean} dimensions
+ * @returns {Array<number>|boolean} dimensions
  */
 function dimensions(buffer) {
     var mp28 = Math.pow(2,8);

--- a/package.json
+++ b/package.json
@@ -21,17 +21,21 @@
     "coveralls": "~2.11.2",
     "tape": "2.13.x",
     "eslint": "~1.00.0",
-    "eslint-config-unstyled": "^1.1.0"
+    "eslint-config-unstyled": "^1.1.0",
+    "@types/node": "^6.0.52",
+    "typescript": "^2.1.4"
   },
   "main": "./index.js",
   "scripts": {
     "test": "eslint index.js && node test/test.js",
     "doc": "dox -r < index.js | doxme --readme > README.md",
-    "coverage": "istanbul cover tape test/*test.js && coveralls < ./coverage/lcov.info"
+    "coverage": "istanbul cover tape test/*test.js && coveralls < ./coverage/lcov.info",
+    "types": "tsc test/types.ts"
   },
   "bin": {
     "tiletype": "bin/tiletype.js"
   },
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git@github.com:mapbox/tiletype.git"

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,6 @@
+import * as fs from 'fs'
+import * as tiletype from '../'
+
+tiletype.dimensions(fs.readFileSync(__dirname + '/fixtures/0.jpeg'))
+tiletype.headers(fs.readFileSync(__dirname + '/fixtures/0.jpeg'))
+tiletype.type(fs.readFileSync(__dirname + '/fixtures/0.jpeg'))

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs'
 import * as tiletype from '../'
 
-tiletype.dimensions(fs.readFileSync(__dirname + '/fixtures/0.jpeg'))
-tiletype.headers(fs.readFileSync(__dirname + '/fixtures/0.jpeg'))
-tiletype.type(fs.readFileSync(__dirname + '/fixtures/0.jpeg'))
+const dimensions = tiletype.dimensions(fs.readFileSync(__dirname + '/fixtures/0.jpeg'))
+const header = tiletype.headers(fs.readFileSync(__dirname + '/fixtures/0.jpeg'))
+const type = tiletype.type(fs.readFileSync(__dirname + '/fixtures/0.jpeg'))


### PR DESCRIPTION
- In `index.js` fixed minor JS Docs `@returns`
- Added tests for types (optional). By running `tsc test/types.ts` without any errors is a pass.